### PR TITLE
Remove redundant chown command in Ubuntu 24.04 PHP 8.3 Dockerfile

### DIFF
--- a/webserver-ubuntu2404/apache24-php83/Dockerfile
+++ b/webserver-ubuntu2404/apache24-php83/Dockerfile
@@ -66,7 +66,7 @@ COPY webserver-ubuntu2404/apache24-php83/files/docker-entrypoint.sh /docker-entr
 # Create PHP log directory
 RUN mkdir -p /var/log/php \
     && chmod 777 -R /var/log/php \
-    && chown www-data:www-data /var/log/php \
+    && chown www-data:www-data /var/log/php
 
 # Set execute permission for entrypoint script
 RUN chmod +x /docker-entrypoint.sh


### PR DESCRIPTION
## :bookmark_tabs: Summary

Brief description about the content of your PR:

Resolves #<your issue id here>

## :straight_ruler: Design Decisions

Describe the way your implementation works or what design decisions you made if applicable:

### :clipboard: Tasks

Make sure you

- [ ] :computer: tests
- [ ] :bookmark: targeted `develop` branch
